### PR TITLE
Setup minimal Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+  language: python
+  python:
+    - "3.6"
+    - "nightly"
+  script:
+    - python manage.py test


### PR DESCRIPTION
Jenkins requires delicated private server to run CI.
On the contrary, Travis CI is available for open source projects.
Thus, we could leverage Travis CI until we are no longer in the free
tier.