### PR TITLE
CI - add test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,29 @@
+[run]
+branch = True
+omit =
+    .env/*
+    manage.py
+    **/migrations/*
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
+ignore_errors = True
+
+[html]
+directory = coverage_html_report

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r ./requirements.txt
+coverage>=4.5


### PR DESCRIPTION
To use this coverage tool, run

```
coverage run manage.py test
coverage report
```

This gives the current coverage of our tests:
```
Name                      Stmts   Miss Branch BrPart  Cover
-----------------------------------------------------------
MIT_backend/__init__.py       2      0      0      0   100%
MIT_backend/settings.py      21      0      0      0   100%
MIT_backend/urls.py           3      0      0      0   100%
accounts/__init__.py          2      0      0      0   100%
accounts/admin.py             3      0      0      0   100%
accounts/models.py           25      1      2      0    96%
accounts/serializers.py      18      0      0      0   100%
accounts/tests.py           152      0      2      0   100%
accounts/tokens.py            7      0      0      0   100%
accounts/urls.py              4      0      0      0   100%
accounts/views.py            53      4      8      3    89%
-----------------------------------------------------------
TOTAL                       290      5     12      3    97%
```